### PR TITLE
Write constraint register

### DIFF
--- a/src/html/html_cli.rs
+++ b/src/html/html_cli.rs
@@ -351,6 +351,7 @@ fn parse_register(
         "description": rtag.description.as_deref().map(sanitize),
         "resetValue": format!("0x{:08X}", rtag.properties.reset_value.unwrap_or_default()),
         "access": raccs,
+        "writeConstraint": rtag.write_constraint,
         "fields": fields,
         "table": table,
         "fields_total": register_fields_total,

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -171,11 +171,15 @@ nav.menu a {
               </a>
             </h4>
             <p>{{ register.description }}</p>
-            <p>Offset: {{ register.offset }}, size: {{ register.size }}, reset: {{ register.resetValue }}, access: {{ register.access }}</p>
+            <p>
+              Offset: {{ register.offset }}, size: {{ register.size }}, reset: {{ register.resetValue }}, access: {{ register.access 
+              }}{% if register.writeConstraint.range %}, allowed values: {{ register.writeConstraint.range.minimum }}-{{ register.writeConstraint.range.maximum }}{% endif %}
+            </p>
             <div class="progress">
               
               <div class="progress-bar progress-bar-success" style="width: {{ register.progress }}%"></div>
             </div>
+            {% if register.fields_total > 0 %}
             <p>
               <em>
                 {{ register.fields_documented}}/{{ register.fields_total }}
@@ -215,6 +219,7 @@ nav.menu a {
                 </div>
               </div>
             </div>
+            {% endif %}
             <div class="container fields" id="{{ pname }}-{{ register.name }}-fields">
               {% for field in register.fields %}
               <div class="row">

--- a/src/patch/peripheral.rs
+++ b/src/patch/peripheral.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context};
 use svd_parser::svd::{
     self, Cluster, ClusterInfo, DimElement, Interrupt, Peripheral, Register, RegisterCluster,
-    RegisterInfo, WriteConstraint, WriteConstraintRange,
+    RegisterInfo,
 };
 use yaml_rust::{yaml::Hash, Yaml};
 
@@ -417,30 +417,6 @@ impl RegisterBlockExt for Peripheral {
             let dim = make_dim_element(rmod)?;
             for rtag in rtags {
                 modify_dim_element(rtag, &dim)?;
-                if let Some(value) = rmod
-                    .get(&"_write_constraint".to_yaml())
-                    .or_else(|| rmod.get(&"writeConstraint".to_yaml()))
-                {
-                    let wc = match value {
-                        Yaml::String(s) if s == "none" => {
-                            // Completely remove the existing writeConstraint
-                            None
-                        }
-                        Yaml::String(s) if s == "enum" => {
-                            // Only allow enumerated values
-                            Some(WriteConstraint::UseEnumeratedValues(true))
-                        }
-                        Yaml::Array(a) => {
-                            // Allow a certain range
-                            Some(WriteConstraint::Range(WriteConstraintRange {
-                                min: a[0].i64()? as u64,
-                                max: a[1].i64()? as u64,
-                            }))
-                        }
-                        _ => return Err(anyhow!("Unknown writeConstraint type {value:?}")),
-                    };
-                    rtag.write_constraint = wc;
-                }
                 rtag.modify_from(register_builder.clone(), VAL_LVL)?;
                 if let Some("") = rmod.get_str("access")? {
                     rtag.properties.access = None;
@@ -905,30 +881,6 @@ impl RegisterBlockExt for Cluster {
             let dim = make_dim_element(rmod)?;
             for rtag in rtags {
                 modify_dim_element(rtag, &dim)?;
-                if let Some(value) = rmod
-                    .get(&"_write_constraint".to_yaml())
-                    .or_else(|| rmod.get(&"writeConstraint".to_yaml()))
-                {
-                    let wc = match value {
-                        Yaml::String(s) if s == "none" => {
-                            // Completely remove the existing writeConstraint
-                            None
-                        }
-                        Yaml::String(s) if s == "enum" => {
-                            // Only allow enumerated values
-                            Some(WriteConstraint::UseEnumeratedValues(true))
-                        }
-                        Yaml::Array(a) => {
-                            // Allow a certain range
-                            Some(WriteConstraint::Range(WriteConstraintRange {
-                                min: a[0].i64()? as u64,
-                                max: a[1].i64()? as u64,
-                            }))
-                        }
-                        _ => return Err(anyhow!("Unknown writeConstraint type {value:?}")),
-                    };
-                    rtag.write_constraint = wc;
-                }
                 rtag.modify_from(register_builder.clone(), VAL_LVL)?;
                 if let Some("") = rmod.get_str("access")? {
                     rtag.properties.access = None;

--- a/src/patch/peripheral.rs
+++ b/src/patch/peripheral.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context};
 use svd_parser::svd::{
     self, Cluster, ClusterInfo, DimElement, Interrupt, Peripheral, Register, RegisterCluster,
-    RegisterInfo,
+    RegisterInfo, WriteConstraint, WriteConstraintRange,
 };
 use yaml_rust::{yaml::Hash, Yaml};
 
@@ -417,6 +417,30 @@ impl RegisterBlockExt for Peripheral {
             let dim = make_dim_element(rmod)?;
             for rtag in rtags {
                 modify_dim_element(rtag, &dim)?;
+                if let Some(value) = rmod
+                    .get(&"_write_constraint".to_yaml())
+                    .or_else(|| rmod.get(&"writeConstraint".to_yaml()))
+                {
+                    let wc = match value {
+                        Yaml::String(s) if s == "none" => {
+                            // Completely remove the existing writeConstraint
+                            None
+                        }
+                        Yaml::String(s) if s == "enum" => {
+                            // Only allow enumerated values
+                            Some(WriteConstraint::UseEnumeratedValues(true))
+                        }
+                        Yaml::Array(a) => {
+                            // Allow a certain range
+                            Some(WriteConstraint::Range(WriteConstraintRange {
+                                min: a[0].i64()? as u64,
+                                max: a[1].i64()? as u64,
+                            }))
+                        }
+                        _ => return Err(anyhow!("Unknown writeConstraint type {value:?}")),
+                    };
+                    rtag.write_constraint = wc;
+                }
                 rtag.modify_from(register_builder.clone(), VAL_LVL)?;
                 if let Some("") = rmod.get_str("access")? {
                     rtag.properties.access = None;
@@ -881,6 +905,30 @@ impl RegisterBlockExt for Cluster {
             let dim = make_dim_element(rmod)?;
             for rtag in rtags {
                 modify_dim_element(rtag, &dim)?;
+                if let Some(value) = rmod
+                    .get(&"_write_constraint".to_yaml())
+                    .or_else(|| rmod.get(&"writeConstraint".to_yaml()))
+                {
+                    let wc = match value {
+                        Yaml::String(s) if s == "none" => {
+                            // Completely remove the existing writeConstraint
+                            None
+                        }
+                        Yaml::String(s) if s == "enum" => {
+                            // Only allow enumerated values
+                            Some(WriteConstraint::UseEnumeratedValues(true))
+                        }
+                        Yaml::Array(a) => {
+                            // Allow a certain range
+                            Some(WriteConstraint::Range(WriteConstraintRange {
+                                min: a[0].i64()? as u64,
+                                max: a[1].i64()? as u64,
+                            }))
+                        }
+                        _ => return Err(anyhow!("Unknown writeConstraint type {value:?}")),
+                    };
+                    rtag.write_constraint = wc;
+                }
                 rtag.modify_from(register_builder.clone(), VAL_LVL)?;
                 if let Some("") = rmod.get_str("access")? {
                     rtag.properties.access = None;


### PR DESCRIPTION
Support for register write constraint

```yaml
ERTC:
  _modify:
    WP:
      size: 8
      writeConstraint: [0, 0xFF]
```

```xml
<register>
  <name>WP</name>
  <displayName>WP</displayName>
  <description>write protection register</description>
  <addressOffset>0x24</addressOffset>
  <size>0x8</size>
  <access>write-only</access>
  <resetValue>0x00000000</resetValue>
  <writeConstraint>
    <range>
      <minimum>0</minimum>
      <maximum>255</maximum>
    </range>
  </writeConstraint>
</register>
```

Also disable 'Field toggle' for no field register in html
![image](https://github.com/rust-embedded/svdtools/assets/39294101/04dae664-a775-4b5e-a195-8b5ca0d3e6e8)
