### PR TITLE
use register size as dimIncrement for 1-element arrays

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -6,6 +6,7 @@ This changelog tracks the Rust `svdtools` project. See
 ## [Unreleased]
 
 * Improve "Could not find errors"
+* use register size as dimIncrement for 1-element arrays
 
 ## [v0.3.3] 2023-10-02
 

--- a/src/patch/peripheral.rs
+++ b/src/patch/peripheral.rs
@@ -1202,7 +1202,15 @@ fn collect_in_array(
         .iter()
         .map(|r| r.address_offset)
         .collect::<Vec<_>>();
-    let dim_increment = if dim > 1 { offsets[1] - offsets[0] } else { 0 };
+    let dim_increment = if dim > 1 {
+        offsets[1] - offsets[0]
+    } else {
+        registers[0]
+            .properties
+            .size
+            .map(|s| s / 8)
+            .unwrap_or_default()
+    };
     if !check_offsets(&offsets, dim_increment) {
         return Err(anyhow!(
             "{}: registers cannot be collected into {rspec} array. Different addressOffset increments",


### PR DESCRIPTION
workaround for `svdconv` M366 error