### PR TITLE
derive fields instead of enums

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,8 @@ This changelog tracks the Rust `svdtools` project. See
 
 ## [Unreleased]
 
+* Add `--enum_derive` flag
+
 ## [v0.3.6] 2023-11-01
 
 * Fix #184

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,13 @@ use clap::Parser;
 use std::path::PathBuf;
 
 use svdtools::{
-    convert::convert_cli, html::html_cli, html::htmlcompare_cli, interrupts::interrupts_cli,
-    makedeps::makedeps_cli, mmap::mmap_cli, patch::patch_cli,
+    convert::convert_cli,
+    html::html_cli,
+    html::htmlcompare_cli,
+    interrupts::interrupts_cli,
+    makedeps::makedeps_cli,
+    mmap::mmap_cli,
+    patch::{patch_cli, EnumAutoDerive},
 };
 
 #[derive(Parser, Debug)]
@@ -27,6 +32,10 @@ enum Command {
         /// When a patch error happens print formatted yaml with all rules included
         #[clap(long)]
         show_patch_on_error: bool,
+
+        /// Derive level when several identical enumerationValues added in a field
+        #[clap(long)]
+        enum_derive: Option<EnumAutoDerive>,
     },
     /// Generate Make dependency file listing dependencies for a YAML file.
     Makedeps {
@@ -117,9 +126,13 @@ impl Command {
                 out_path,
                 format_config,
                 show_patch_on_error,
+                enum_derive,
             } => {
                 let mut config = svdtools::patch::Config::default();
                 config.show_patch_on_error = *show_patch_on_error;
+                if let Some(enum_derive) = enum_derive.as_ref() {
+                    config.enum_derive = *enum_derive;
+                }
                 patch_cli::patch(
                     yaml_file,
                     out_path.as_deref(),

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -31,9 +31,35 @@ use crate::get_encoder_config;
 const VAL_LVL: ValidateLevel = ValidateLevel::Weak;
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub show_patch_on_error: bool,
+    pub enum_derive: EnumAutoDerive,
+    pub update_fields: bool,
+}
+
+/// Derive level when several identical enumerationValues added in a field
+#[derive(clap::ValueEnum)]
+#[value(rename_all = "lower")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum EnumAutoDerive {
+    #[default]
+    /// Derive enumeratedValues
+    Enum,
+    /// Derive fields
+    Field,
+    /// Make a copy
+    None,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            show_patch_on_error: false,
+            enum_derive: Default::default(),
+            update_fields: true,
+        }
+    }
 }
 
 pub fn process_file(
@@ -76,7 +102,7 @@ pub fn process_file(
     yaml_includes(root)?;
 
     // Process device
-    svd.process(root, true).with_context(|| {
+    svd.process(root, config).with_context(|| {
         let name = &svd.name;
         let mut out_str = String::new();
         let mut emitter = yaml_rust::YamlEmitter::new(&mut out_str);


### PR DESCRIPTION
Do not change default behavior, but add option flag.

With `--enum derive field` this fixes most of `svdconv` M206 errors. Although I can't guarantee this doesn't break anything.
