### PR TITLE
Remove/replace occurrences of "stm32-rs" in the HTML templates

### DIFF
--- a/src/html/index.template.html
+++ b/src/html/index.template.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name=viewport content="width=device-width, initial-scale=1">
-<title>stm32-rs Device Coverage</title>
+<title>Device Coverage</title>
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 </head>
@@ -13,7 +13,7 @@
 <nav class="navbar navbar-inverse">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand active" href="#"">stm32-rs Device Coverage</a>
+      <a class="navbar-brand active" href="#"">Device Coverage</a>
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -67,7 +67,7 @@ nav.menu a {
 <nav class="navbar navbar-inverse">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="index.html">stm32-rs Device Coverage</a>
+      <a class="navbar-brand" href="index.html">{{ device.name }} Device Coverage</a>
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">


### PR DESCRIPTION
Just happened to notice this 😅 For the index I've just removed the `stm32-rs` text altogether, and in the device template I've used the device's name instead.