### PR TITLE
Process `displayName` in collection registers in array

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -6,6 +6,7 @@ This changelog tracks the Rust `svdtools` project. See
 ## [Unreleased]
 
 * Move field with derived enums before other
+* Support `displayName` in `_array` of registers
 
 ## [v0.3.4] 2023-10-14
 

--- a/src/patch/peripheral.rs
+++ b/src/patch/peripheral.rs
@@ -1217,11 +1217,18 @@ fn collect_in_array(
         if desc != "_original" {
             rinfo.description = Some(desc.into());
         }
-    } else if dim_index[0] == "0" {
-        if let Some(desc) = rinfo.description.as_mut() {
-            *desc = desc.replace('0', "%s");
-        }
+    } else if let Some(desc) = rinfo.description.as_mut() {
+        *desc = desc.replace(&dim_index[0], "%s");
     }
+
+    if let Some(dname) = rmod.get_str("displayName")? {
+        if dname != "_original" {
+            rinfo.display_name = Some(dname.into());
+        }
+    } else if let Some(dname) = rinfo.display_name.as_mut() {
+        *dname = dname.replace(&dim_index[0], "%s");
+    }
+
     let mut reg = rinfo.array(
         DimElement::builder()
             .dim(dim as u32)


### PR DESCRIPTION
add support syntax

```yaml
  _array:
    PCDTO?:
      displayName: PCDTO%s
      description: Data offset for Preempted channel %s
```

If `displayName` patch not provided, replaces index with "%s"