### PR TITLE
html: multiple template fixes

### DIFF
--- a/src/html/htmlcompare_cli.rs
+++ b/src/html/htmlcompare_cli.rs
@@ -42,21 +42,22 @@ fn html_page(title: &str, table: &str) -> String {
 <head>
     <meta charset="UTF-8">"#,
         &title,
-        r##"</head>
-<style>
-table thead tr th {
-    position: sticky;
-    top: 0;
-    z-index: 6;
-    background: white;
-}
-td:first-child {
-    position: sticky;
-    left: 0;
-    z-index: 5;
-    background: white;
-}
-</style>
+        r##"
+    <style>
+    table thead tr th {
+        position: sticky;
+        top: 0;
+        z-index: 6;
+        background: white;
+    }
+    td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 5;
+        background: white;
+    }
+    </style>
+</head>
 <body>"##,
         &header,
         table,

--- a/src/html/index.template.html
+++ b/src/html/index.template.html
@@ -13,7 +13,7 @@
 <nav class="navbar navbar-inverse">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand active" href="#"">Device Coverage</a>
+      <a class="navbar-brand active" href="#">Device Coverage</a>
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -30,9 +30,6 @@
 .headerlink {
   font-size: 50%;
 }
-.fields {
-  display: none;
-}
 nav.menu {
   line-height: 2
 }
@@ -205,12 +202,12 @@ summary {
                     </tr>
                     {% endif %}{% endfor %}
                   </tbody></table>
-                  <a href="#" class="toggle-fields">Toggle Fields</a>
                 </div>
               </div>
             </div>
             {% endif %}
-            <div class="container fields" id="{{ pname }}-{{ register.name }}-fields">
+            <details class="fields" id="{{ pname }}-{{ register.name }}-fields">
+              <summary>Toggle fields</summary>
               {% for field in register.fields %}
               <div class="row">
                 <div class="col-sm-10">
@@ -235,7 +232,7 @@ summary {
                 </div>
               </div>
               {% endfor %}
-            </div>
+            </details>
           </div>
         </div>
         {% endfor %}
@@ -257,27 +254,18 @@ summary {
     document.querySelectorAll('.registers').forEach(el => el.open = false)
     e.preventDefault()
   })
-  $('.fieldlink').click(function(e) {
-    $(this).parents(".container").first().siblings(".fields").show();
-  });
-  $('.toggle-fields').click(function(e) {
-    $(this).parents(".container").first().siblings(".fields").toggle();
-    e.preventDefault();
-  });
-  if (window.location.hash?.includes(":")) {
-    const hash = window.location.hash;
-    const [peripheral, register, field] = hash.substr(1).split(":", 3)
-    if (document.getElementById(`${peripheral}-registers`)) {
+  function locationHashChanged() {
+    const [peripheral, register, field] = window.location.hash.substr(1).split(":", 3)
+    if (register && document.getElementById(`${peripheral}-registers`)) {
       document.getElementById(`${peripheral}-registers`).open = true
     }
-    if(field) {
-      $('#' + peripheral + '-' + register + '-fields').show(0, function() {
-        window.location.hash = hash
-      })
-    } else {
-      window.location.hash = hash
+    if(field && document.getElementById(`${peripheral}-${register}-fields`)) {
+      document.getElementById(`${peripheral}-${register}-fields`).open = true
     }
+    window.location.hash = window.location.hash
   }
+  window.addEventListener("hashchange", locationHashChanged)
+  locationHashChanged()
   $(function () {
     $('[data-toggle="popover"]').popover()
   })

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -242,9 +242,6 @@ summary {
   {% endfor %}
 </div>
 
-<script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-
 <script>
   document.getElementById('show-all-registers').addEventListener('click', e => {
     document.querySelectorAll('.registers').forEach(el => el.open = true)

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -7,20 +7,10 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 <style>
-.peripheral {
+.peripheral, .register, .field {
   border-radius: 3px;
   border: solid 1px #eee;
   margin-bottom: 5px;
-}
-.register {
-  border-radius: 3px;
-  border: solid 1px #eee;
-  margin-bottom: 3px;
-}
-.field {
-  border-radius: 3px;
-  border: solid 1px #eee;
-  margin-bottom: 3px;
 }
 .registers,
 .register-map {

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -266,9 +266,6 @@ summary {
   }
   window.addEventListener("hashchange", locationHashChanged)
   locationHashChanged()
-  $(function () {
-    $('[data-toggle="popover"]').popover()
-  })
 </script>
 
 </body>

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -7,10 +7,14 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 <style>
-.peripheral, .register, .field {
+.peripheral, .register {
   border-radius: 3px;
   border: solid 1px #eee;
-  margin-bottom: 5px;
+  margin: 1rem 0;
+  padding: 1rem;
+}
+.peripheral h3, .register h4 {
+  margin-top: 0;
 }
 .bitfield td, .bitfield th {
   text-align: center;
@@ -93,151 +97,139 @@ summary {
     {% endfor %}
   </nav>
   {% for peripheral in device.peripherals %}{% assign pname = peripheral.name %}
-  <div class="row">
-    <div class="col-sm-12 peripheral">
-      <h3>
-        <a name="{{ pname }}"></a>
-        {{ pname }}
-        <a class="headerlink" href="#{{ pname }}">
-          <span class="glyphicon glyphicon-link"></span>
-        </a>
-      </h3>
-      <p>{{ peripheral.base }}: {{ peripheral.description }}</p>
-      <div class="progress">
-        
-        <div class="progress-bar progress-bar-success" style="width: {{ peripheral.progress }}%"></div>
-      </div>
-      <p>
-        <em>
-          {{ peripheral.fields_documented }}/{{peripheral.fields_total }}
-          fields covered.
-        </em>
-      </p>
-      <details class="register-map" id="{{ pname }}-register-map">
-        <summary>Toggle register map</summary>
-        <table class="table table-bordered register-map-table">
-          <tbody><tr>
-            <th>Offset</th>
-            <th>Name</th>
-            {% for i in (0..31) reversed %}
-            <th class="vertical"><div>{{ i }}</div></th>
-            {% endfor %}
-          </tr>
-          {% for register in peripheral.registers %}
-            <tr>
-              <td>{{ register.offset }}{% if register.size != 32 %} ({{ register.size }}-bit){% endif %}</td>
-              <td>{{ register.name }}</td>
-              {% for row in register.table %}{% if row %}
-                {% for field in row.fields %}
-                  {% unless field.name %}
-                    {% for _ in (1..field.width) %}
-                    <td{% if field.separated %} class="separated"{% endif %}></td>
-                    {% endfor %}
-                  {% endunless %}
-                  {% if field.name %}
-                    <td colspan="{{ field.width }}" class="vertical{% if field.separated %} separated{% endif %}">
-                      <div><a class="fieldlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">{{ field.name }}</a></div>
-                    </td>
-                  {% endif %}
-                {% endfor %}
-              {% else %}{% for _ in (1..16) %}<td></td>{% endfor %}{% endif %}{% endfor %}
-            </tr>
-          {% endfor %}
-        </tbody></table>
-      </details>
-      <details class="registers" id="{{ pname }}-registers">
-        <summary>Toggle registers</summary>
-        {% for register in peripheral.registers %}
-        <div class="row">
-          <div class="col-sm-11 register">
-            <h4>
-              <a name="{{ pname }}:{{ register.name }}"></a>
-              {{ register.name }}
-              <a class="headerlink" href="#{{ pname }}:{{ register.name }}">
-                <span class="glyphicon glyphicon-link"></span>
-              </a>
-            </h4>
-            <p>{{ register.description }}</p>
-            <p>
-              Offset: {{ register.offset }}, size: {{ register.size }}, reset: {{ register.resetValue }}, access: {{ register.access 
-              }}{% if register.writeConstraint.range %}, allowed values: {{ register.writeConstraint.range.minimum }}-{{ register.writeConstraint.range.maximum }}{% endif %}
-            </p>
-            <div class="progress">
-              
-              <div class="progress-bar progress-bar-success" style="width: {{ register.progress }}%"></div>
-            </div>
-            {% if register.fields_total > 0 %}
-            <p>
-              <em>
-                {{ register.fields_documented}}/{{ register.fields_total }}
-                fields covered.
-              </em>
-            </p>
-            <div class="container bitfield">
-              <div class="row">
-                <div class="col-sm-10">
-                  <table class="table table-striped table-bordered bitfield">
-                    <tbody>{% for row in register.table %}{% if row %}
-                    <tr>
-                      {% for header in row.headers %}
-                      <th>{{ header }}</th>
-                      {% endfor %}
-                    </tr>
-                    <tr>
-                      {% for field in row.fields %}
-                      <td colspan="{{ field.width }}"{% if field.separated %} class="separated"{% endif %}>
-                        {% if field.name %}
-                        <a class="fieldlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">
-                        {% if field.doc %}
-                        <span class="doccol">
-                        {% else %}
-                        <span>
-                        {% endif %}
-                        {{ field.name }}</span></a>
-                        <br>
-                        {{ field.access }}
-                        {% endif %}
-                      </td>
-                      {% endfor %}
-                    </tr>
-                    {% endif %}{% endfor %}
-                  </tbody></table>
-                </div>
-              </div>
-            </div>
-            {% endif %}
-            <details class="fields" id="{{ pname }}-{{ register.name }}-fields">
-              <summary>Toggle fields</summary>
-              {% for field in register.fields %}
-              <div class="row">
-                <div class="col-sm-10">
-                  <h4>
-                    <a name="{{ pname }}:{{ register.name }}:{{ field.name }}">
-                    </a>
-                    {{ field.name }}
-                    <a class="headerlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">
-                      <span class="glyphicon glyphicon-link"></span>
-                    </a>
-                  </h4>
-                  <p>
-                    {% if field.width > 1 %}
-                      Bits {{ field.offset }}-{{ field.msb }}:
-                    {% else %}
-                      Bit {{ field.offset }}:
-                    {% endif %}
-                    {{ field.description }}.</p>
-                  {% if field.doc %}
-                  <p>{{ field.doc }}</p>
-                  {% endif %}
-                </div>
-              </div>
-              {% endfor %}
-            </details>
-          </div>
-        </div>
-        {% endfor %}
-      </details>
+  <div class="peripheral">
+    <h3>
+      <a name="{{ pname }}"></a>
+      {{ pname }}
+      <a class="headerlink" href="#{{ pname }}">
+        <span class="glyphicon glyphicon-link"></span>
+      </a>
+    </h3>
+    <p>{{ peripheral.base }}: {{ peripheral.description }}</p>
+    <div class="progress">
+
+      <div class="progress-bar progress-bar-success" style="width: {{ peripheral.progress }}%"></div>
     </div>
+    <p>
+      <em>
+        {{ peripheral.fields_documented }}/{{peripheral.fields_total }}
+        fields covered.
+      </em>
+    </p>
+    <details class="register-map" id="{{ pname }}-register-map">
+      <summary>Toggle register map</summary>
+      <table class="table table-bordered register-map-table">
+        <tbody><tr>
+          <th>Offset</th>
+          <th>Name</th>
+          {% for i in (0..31) reversed %}
+          <th class="vertical"><div>{{ i }}</div></th>
+          {% endfor %}
+        </tr>
+        {% for register in peripheral.registers %}
+          <tr>
+            <td>{{ register.offset }}{% if register.size != 32 %} ({{ register.size }}-bit){% endif %}</td>
+            <td>{{ register.name }}</td>
+            {% for row in register.table %}{% if row %}
+              {% for field in row.fields %}
+                {% unless field.name %}
+                  {% for _ in (1..field.width) %}
+                  <td{% if field.separated %} class="separated"{% endif %}></td>
+                  {% endfor %}
+                {% endunless %}
+                {% if field.name %}
+                  <td colspan="{{ field.width }}" class="vertical{% if field.separated %} separated{% endif %}">
+                    <div><a class="fieldlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">{{ field.name }}</a></div>
+                  </td>
+                {% endif %}
+              {% endfor %}
+            {% else %}{% for _ in (1..16) %}<td></td>{% endfor %}{% endif %}{% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody></table>
+    </details>
+    <details class="registers" id="{{ pname }}-registers">
+      <summary>Toggle registers</summary>
+      {% for register in peripheral.registers %}
+      <div class="register">
+        <h4>
+          <a name="{{ pname }}:{{ register.name }}"></a>
+          {{ register.name }}
+          <a class="headerlink" href="#{{ pname }}:{{ register.name }}">
+            <span class="glyphicon glyphicon-link"></span>
+          </a>
+        </h4>
+        <p>{{ register.description }}</p>
+        <p>
+          Offset: {{ register.offset }}, size: {{ register.size }}, reset: {{ register.resetValue }}, access: {{ register.access
+          }}{% if register.writeConstraint.range %}, allowed values: {{ register.writeConstraint.range.minimum }}-{{ register.writeConstraint.range.maximum }}{% endif %}
+        </p>
+        <div class="progress">
+
+          <div class="progress-bar progress-bar-success" style="width: {{ register.progress }}%"></div>
+        </div>
+        {% if register.fields_total > 0 %}
+        <p>
+          <em>
+            {{ register.fields_documented}}/{{ register.fields_total }}
+            fields covered.
+          </em>
+        </p>
+        <div class="bitfield">
+          <table class="table table-striped table-bordered bitfield">
+            <tbody>{% for row in register.table %}{% if row %}
+            <tr>
+              {% for header in row.headers %}
+              <th>{{ header }}</th>
+              {% endfor %}
+            </tr>
+            <tr>
+              {% for field in row.fields %}
+              <td colspan="{{ field.width }}"{% if field.separated %} class="separated"{% endif %}>
+                {% if field.name %}
+                <a class="fieldlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">
+                {% if field.doc %}
+                <span class="doccol">
+                {% else %}
+                <span>
+                {% endif %}
+                {{ field.name }}</span></a>
+                <br>
+                {{ field.access }}
+                {% endif %}
+              </td>
+              {% endfor %}
+            </tr>
+            {% endif %}{% endfor %}
+          </tbody></table>
+        </div>
+        {% endif %}
+        <details class="fields" id="{{ pname }}-{{ register.name }}-fields">
+          <summary>Toggle fields</summary>
+          {% for field in register.fields %}
+          <h4>
+            <a name="{{ pname }}:{{ register.name }}:{{ field.name }}">
+            </a>
+            {{ field.name }}
+            <a class="headerlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">
+              <span class="glyphicon glyphicon-link"></span>
+            </a>
+          </h4>
+          <p>
+            {% if field.width > 1 %}
+              Bits {{ field.offset }}-{{ field.msb }}:
+            {% else %}
+              Bit {{ field.offset }}:
+            {% endif %}
+            {{ field.description }}.</p>
+          {% if field.doc %}
+          <p>{{ field.doc }}</p>
+          {% endif %}
+          {% endfor %}
+        </details>
+      </div>
+      {% endfor %}
+    </details>
   </div>
   {% endfor %}
 </div>

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -12,8 +12,7 @@
   border: solid 1px #eee;
   margin-bottom: 5px;
 }
-.registers,
-.register-map {
+.registers {
   display: none;
 }
 .bitfield td, .bitfield th {
@@ -48,6 +47,10 @@ nav.menu a {
 }
 .bitfield td.separated {
   background-color:#eee;
+}
+summary {
+  /* fix bootstrap 2 bug, https://github.com/twbs/bootstrap/issues/21060 */
+  display: list-item;
 }
 </style>
 </head>
@@ -117,8 +120,8 @@ nav.menu a {
         </em>
         <a class="toggle-registers" href="#">Toggle Registers</a>
       </p>
-      <p><a class="toggle-register-map" href="#">Show register map</a></p>
-      <div class="register-map" id="{{ pname }}-register-map">
+      <details class="register-map" id="{{ pname }}-register-map">
+        <summary>Toggle register map</summary>
         <table class="table table-bordered register-map-table">
           <tbody><tr>
             <th>Offset</th>
@@ -148,7 +151,7 @@ nav.menu a {
             </tr>
           {% endfor %}
         </tbody></table>
-      </div>
+      </details>
       <div class="container registers" id="{{ pname }}-registers">
         {% for register in peripheral.registers %}
         <div class="row">
@@ -251,10 +254,6 @@ nav.menu a {
 <script>
   $('.toggle-registers').click(function(e) {
     $(this).parent().siblings(".registers").toggle();
-    e.preventDefault();
-  });
-  $('.toggle-register-map').click(function(e) {
-    $(this).parent().siblings(".register-map").toggle();
     e.preventDefault();
   });
   $('#show-all-registers').click(function(e) {

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -12,9 +12,6 @@
   border: solid 1px #eee;
   margin-bottom: 5px;
 }
-.registers {
-  display: none;
-}
 .bitfield td, .bitfield th {
   text-align: center;
 }
@@ -118,7 +115,6 @@ summary {
           {{ peripheral.fields_documented }}/{{peripheral.fields_total }}
           fields covered.
         </em>
-        <a class="toggle-registers" href="#">Toggle Registers</a>
       </p>
       <details class="register-map" id="{{ pname }}-register-map">
         <summary>Toggle register map</summary>
@@ -152,7 +148,8 @@ summary {
           {% endfor %}
         </tbody></table>
       </details>
-      <div class="container registers" id="{{ pname }}-registers">
+      <details class="registers" id="{{ pname }}-registers">
+        <summary>Toggle registers</summary>
         {% for register in peripheral.registers %}
         <div class="row">
           <div class="col-sm-11 register">
@@ -242,7 +239,7 @@ summary {
           </div>
         </div>
         {% endfor %}
-      </div>
+      </details>
     </div>
   </div>
   {% endfor %}
@@ -252,18 +249,14 @@ summary {
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <script>
-  $('.toggle-registers').click(function(e) {
-    $(this).parent().siblings(".registers").toggle();
-    e.preventDefault();
-  });
-  $('#show-all-registers').click(function(e) {
-    $('.registers').show();
-    e.preventDefault();
-  });
-  $('#hide-all-registers').click(function(e) {
-    $('.registers').hide();
-    e.preventDefault();
-  });
+  document.getElementById('show-all-registers').addEventListener('click', e => {
+    document.querySelectorAll('.registers').forEach(el => el.open = true)
+    e.preventDefault()
+  })
+  document.getElementById('hide-all-registers').addEventListener('click', e => {
+    document.querySelectorAll('.registers').forEach(el => el.open = false)
+    e.preventDefault()
+  })
   $('.fieldlink').click(function(e) {
     $(this).parents(".container").first().siblings(".fields").show();
   });
@@ -271,20 +264,19 @@ summary {
     $(this).parents(".container").first().siblings(".fields").toggle();
     e.preventDefault();
   });
-  if(window.location.hash && window.location.hash.includes(":")) {
-    var hash = window.location.hash;
-    var parts = hash.substr(1).split(":");
-    var peripheral = parts[0];
-    var register = parts[1];
-    $('#' + peripheral + '-registers').show(0, function() {
-      if(parts.length == 3) {
-        $('#' + peripheral + '-' + register + '-fields').show(0, function() {
-          window.location.hash = hash;
-        });
-      } else {
-        window.location.hash = hash;
-      }
-    });
+  if (window.location.hash?.includes(":")) {
+    const hash = window.location.hash;
+    const [peripheral, register, field] = hash.substr(1).split(":", 3)
+    if (document.getElementById(`${peripheral}-registers`)) {
+      document.getElementById(`${peripheral}-registers`).open = true
+    }
+    if(field) {
+      $('#' + peripheral + '-' + register + '-fields').show(0, function() {
+        window.location.hash = hash
+      })
+    } else {
+      window.location.hash = hash
+    }
   }
   $(function () {
     $('[data-toggle="popover"]').popover()

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -35,13 +35,15 @@
   font-size: 50%;
 }
 nav.menu {
-  line-height: 2
+  margin: 1rem 0;
 }
 nav.menu a {
-  display: block-inline;
-  border-radius: 5px;
+  display: inline-block;
+  border-radius: 3px;
   border: solid 1px #ccc;
-  padding: 3pt;
+  padding: 0.3rem;
+  margin: 0.1rem;
+  text-decoration: none;
 }
 .bitfield td.separated {
   background-color:#eee;
@@ -84,11 +86,6 @@ summary {
         <div class="progress-bar progress-bar-success" style="width: {{ device.progress }}%">
         </div>
       </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-1"></div>
-    <div class="col-sm-9">
     </div>
   </div>
   <nav class="menu">


### PR DESCRIPTION
This pull request proposes some improvement to the HTML templates:

- Fix `<style>` being used outside of `<head>` in `htmlcompare`
- Use `<details>` elements and drop JavaScript (JQuery+Bootstrap JS)
- Some CSS fixes to remove unwanted elements overlap.

Thank you for this awesome project!