### PR TITLE
html/template.html: fix location hash redirect

### DIFF
--- a/src/html/template.html
+++ b/src/html/template.html
@@ -251,7 +251,9 @@ details[open] > summary {
     if(field && document.getElementById(`${peripheral}-${register}-fields`)) {
       document.getElementById(`${peripheral}-${register}-fields`).open = true
     }
-    window.location.hash = window.location.hash
+    if (window.location.hash) {
+      window.location.hash = window.location.hash
+    }
   }
   window.addEventListener("hashchange", locationHashChanged)
   locationHashChanged()


### PR DESCRIPTION
When no hash is present in the URL, `locationHashChanged` JavaScript function will add an extra `#` symbol at the end of the URL. This is problematic as it adds another entry in the browser history, making it impossible to go back to previous page using the browser 'back button'.

Sorry for introducing this bug in https://github.com/rust-embedded/svdtools/pull/198.