### PR TITLE
Add a name element to the children of an enumaratedValues element with the "derivedFrom" attribute.

### DIFF
--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -353,9 +353,10 @@ fn make_ev_array(values: &Hash) -> Result<EnumeratedValuesBuilder> {
 }
 
 /// Returns an enumeratedValues Element which is derivedFrom name
-fn make_derived_enumerated_values(name: &str) -> Result<EnumeratedValues> {
+fn make_derived_enumerated_values(derived_name: &str, base_name: &str) -> Result<EnumeratedValues> {
     Ok(EnumeratedValues::builder()
-        .derived_from(Some(name.into()))
+        .name(Some(derived_name.into()))
+        .derived_from(Some(base_name.into()))
         .build(VAL_LVL)?)
 }
 

--- a/src/patch/register.rs
+++ b/src/patch/register.rs
@@ -535,6 +535,7 @@ impl RegisterExt for Register {
             Some(ModifiedWriteValues::OneToToggle),
             Some(ModifiedWriteValues::ZeroToToggle),
         ];
+
         match fmod {
             Yaml::Hash(fmod) => {
                 let is_read = READ_KEYS
@@ -713,7 +714,6 @@ impl RegisterExt for Register {
                     ));
                 }
             };
-            let evs = make_derived_enumerated_values(d)?;
             for ftag in self.iter_fields(fspec) {
                 let access = ftag.access.or(reg_access).unwrap_or_default();
                 let checked_usage = check_usage(access, usage)
@@ -726,7 +726,9 @@ impl RegisterExt for Register {
                 if ftag.name == d {
                     return Err(anyhow!("EnumeratedValues can't be derived from itself"));
                 }
-                set_enum(ftag, evs.clone(), orig_usage, true, access)?;
+                let derived_name = make_ev_name(&ftag.name.replace("%s", ""), usage)?;
+                let evs = make_derived_enumerated_values(&derived_name, d)?;
+                set_enum(ftag, evs, orig_usage, true, access)?;
             }
         } else {
             let (fspec, ignore) = fspec.spec();
@@ -769,9 +771,10 @@ impl RegisterExt for Register {
                         VAL_LVL,
                     )?;
                 } else {
+                    let derived_name = make_ev_name(&ftag.name.replace("%s", ""), usage)?;
                     set_enum(
                         ftag,
-                        make_derived_enumerated_values(&name)?,
+                        make_derived_enumerated_values(&derived_name, &name)?,
                         checked_usage,
                         true,
                         access,


### PR DESCRIPTION
svd file
```XML
    <peripheral>
      <name>RTC</name>
      <description>RTC</description>
      <groupName>RTC</groupName>
      <baseAddress>0x58004000</baseAddress>
        <register>
          <name>RTC_ISR</name>
          <displayName>RTC_ISR</displayName>
          <description>This register is write protected (except for
          RTC_ISR[13:8] bits). The write access procedure is
          described in RTC register write protection on
          page9.</description>
          <addressOffset>0xC</addressOffset>
          <size>0x20</size>
          <resetValue>0x00000007</resetValue>
          <fields>
            <field>
              <name>TAMP1F</name>
              <description>RTC_TAMP1 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP1 input. It is cleared by
              software writing 0</description>
              <bitOffset>13</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
            </field>
            <field>
              <name>TAMP2F</name>
              <description>RTC_TAMP2 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP2 input. It is cleared by
              software writing 0</description>
              <bitOffset>14</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
            </field>
            <field>
              <name>TAMP3F</name>
              <description>RTC_TAMP3 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP3 input. It is cleared by
              software writing 0</description>
              <bitOffset>15</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
            </field>
```

yaml file
```yaml
RTC:
  ISR:
    RECALPF:
      _read:
        Pending: [1, "The RECALPF status flag is automatically set to 1 when sof
tware writes to the RTC_CALR register, indicating that the RTC_CALR register is 
blocked. When the new calibration settings are taken into account, this bit retu
rns to 0"]
    "TAMP*F":
      _read:
        Tampered: [1, "This flag is set by hardware when a tamper detection event is detected on the RTC_TAMPx input"]
      _W0C:
        Clear: [0, "Flag cleared by software writing 0"]
```

patch svd
```XML
            <field>
              <name>TAMP1F</name>
              <description>RTC_TAMP1 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP1 input. It is cleared by
              software writing 0</description>
              <bitOffset>13</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
              <modifiedWriteValues>zeroToClear</modifiedWriteValues>
              <enumeratedValues>
                <name>TAMP1FR</name>
                <usage>read</usage>
                <enumeratedValue>
                  <name>Tampered</name>
                  <description>This flag is set by hardware when a tamper detection event is detected on the RTC_TAMPx input</description>
                  <value>1</value>
                </enumeratedValue>
              </enumeratedValues>
              <enumeratedValues>
                <name>TAMP1FW</name>
                <usage>write</usage>
                <enumeratedValue>
                  <name>Clear</name>
                  <description>Flag cleared by software writing 0</description>
                  <value>0</value>
                </enumeratedValue>
              </enumeratedValues>
            </field>
            <field>
              <name>TAMP2F</name>
              <description>RTC_TAMP2 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP2 input. It is cleared by
              software writing 0</description>
              <bitOffset>14</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
              <modifiedWriteValues>zeroToClear</modifiedWriteValues>
              <enumeratedValues derivedFrom="TAMP1FR">
                <usage>read</usage>
              </enumeratedValues>
              <enumeratedValues derivedFrom="TAMP1FW">
                <usage>write</usage>
              </enumeratedValues>
            </field>
            <field>
              <name>TAMP3F</name>
              <description>RTC_TAMP3 detection flag This flag is
              set by hardware when a tamper detection event is
              detected on the RTC_TAMP3 input. It is cleared by
              software writing 0</description>
              <bitOffset>15</bitOffset>
              <bitWidth>1</bitWidth>
              <access>read-write</access>
              <modifiedWriteValues>zeroToClear</modifiedWriteValues>
              <enumeratedValues derivedFrom="TAMP1FR">
                <usage>read</usage>
              </enumeratedValues>
              <enumeratedValues derivedFrom="TAMP1FW">
                <usage>write</usage>
              </enumeratedValues>
            </field>
```

When a patched svd file is generated from a svd file and a yaml file as described above, when the `access` child element of the `field` element is read-write, an `enumeratedValues` element with the name R,W is added at the end.
However, the derived `enumeratedValues` will not contain the name child elements generated by the naming convention.

In this case, when we would like to generate the following code by `svd2rust` , (I would like to add type alias.)

```Rust
pub type TAMP2FR = TAMP1FR;
```

we have to incorporate the naming convention of `svdtool patch` in `svd2rust`.

If svdtool determines the naming rule of the derived source enumeratedValue, 
the name of the derived destination enumeratedValue should also be added according to the naming rule.
I think that it is not a good idea to make svd2rust guess the naming rule of svdtool.

I am not an English speaker, so I apologize if this is a strange English explanation.