### PR TITLE
specify `name` for `enumeratedValues`

### DIFF
--- a/CHANGELOG-python.md
+++ b/CHANGELOG-python.md
@@ -6,6 +6,7 @@ This changelog tracks the Python `svdtools` project. See
 ## [Unreleased]
 
 * Fix #176 in `collect_in_cluster`
+* Allow to specify `name` for `enumeratedValues`
 
 ## [v0.1.27] 2023-12-23
 

--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,8 @@ This changelog tracks the Rust `svdtools` project. See
 
 ## [Unreleased]
 
+* Allow to specify `name` for `enumeratedValues`
+
 ## [v0.3.9] 2024-01-19
 
 * Use `<details>` instead of JavaScript in `html` template

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ once_cell = "1.18.0"
 rayon = "1.7.0"
 regex = "1.9.1"
 itertools = "0.12.0"
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ rust-version = "1.70"
 clap = { version = "4.4", features = ["derive", "cargo", "color"] }
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.31", features = ["serialize"] }
-svd-rs = { version = "0.14.6", features = ["serde", "derive-from"] }
-svd-parser = { version = "0.14.4", features = ["expand"] }
+svd-rs = { version = "0.14.8", features = ["serde", "derive-from"] }
+svd-parser = { version = "0.14.5", features = ["expand"] }
 svd-encoder = "0.14.4"
 yaml-rust = "0.4"
 # serde_yaml 0.9.x looks broken
@@ -40,13 +40,13 @@ thiserror = "1.0.35"
 linked-hash-map = "0.5"
 globset = "0.4.14"
 commands = "0.0.5"
-env_logger = "0.10"
+env_logger = "0.11"
 log = { version = "~0.4", features = ["std"] }
 normpath = "1.1.0"
 liquid = "0.26.0"
 once_cell = "1.18.0"
 rayon = "1.7.0"
-regex = "1.9.1"
+regex = "1.10"
 itertools = "0.12.0"
 phf = { version = "0.11", features = ["macros"] }
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ _rebase:
 
         # A field in this register, matches an SVD <field> tag
         FIELD:
+            # You can optionally specify name for `enumeratedValues`
+            _name: NAME
             # By giving the field a dictionary we construct an enumerateValues
             VARIANT: [VALUE, DESCRIPTION]
             VARIANT: [VALUE, DESCRIPTION]

--- a/src/patch/register.rs
+++ b/src/patch/register.rs
@@ -742,7 +742,11 @@ impl RegisterExt for Register {
             let (min_offset, fname, min_offset_pos) =
                 offsets.iter().min_by_key(|&on| on.0).unwrap();
             let min_pos = offsets.iter().map(|on| on.2).min().unwrap();
-            let name = make_ev_name(&fname.replace("%s", ""), usage)?;
+            let name = if let Some(name) = fmod.get_str("_name")? {
+                name.to_string()
+            } else {
+                make_ev_name(&fname.replace("%s", ""), usage)?
+            };
             for ftag in self.iter_fields(fspec) {
                 let access = ftag.access.or(reg_access).unwrap_or_default();
                 let checked_usage = check_usage(access, usage)

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -1713,6 +1713,8 @@ class Register:
         for ftag in sorted_fields(list(self.iter_fields(fspec))):
             if "_derivedFrom" in field:
                 derived = field["_derivedFrom"]
+            if "_name" in field:
+                name = field["_name"]
             else:
                 name = ftag.find("name").text
 

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -1713,7 +1713,7 @@ class Register:
         for ftag in sorted_fields(list(self.iter_fields(fspec))):
             if "_derivedFrom" in field:
                 derived = field["_derivedFrom"]
-            if "_name" in field:
+            elif "_name" in field:
                 name = field["_name"]
             else:
                 name = ftag.find("name").text


### PR DESCRIPTION
For example:
```yaml
  "A?B?ENR,A?BENR":
    "*EN":
      _name: Enable
      Disabled: [0, "The selected clock is disabled"]
      Enabled: [1, "The selected clock is enabled"]
```
gives us:
![изображение](https://github.com/rust-embedded/svdtools/assets/3072754/70f9283d-d298-4bb0-bf06-0d45699aadc8)