### PR TITLE
Let opt_interpolate return the plain string if path is None

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,8 @@ This changelog tracks the Rust `svdtools` project. See
 
 ## [Unreleased]
 
+* If there is no path to interpolate, show unmodified `description`.
+
 ## [v0.3.13] 2024-03-29
 
 * Interpolate path and name in `description` and `derivedFrom`

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -805,6 +805,7 @@ impl Spec for str {
 
 fn opt_interpolate<T: Interpolate>(path: &Option<&T>, s: Option<&str>) -> Option<String> {
     path.and_then(|path| path.interpolate_opt(s))
+        .or_else(|| s.map(ToString::to_string))
 }
 
 trait Interpolate {

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -804,8 +804,11 @@ impl Spec for str {
 }
 
 fn opt_interpolate<T: Interpolate>(path: &Option<&T>, s: Option<&str>) -> Option<String> {
-    path.and_then(|path| path.interpolate_opt(s))
-        .or_else(|| s.map(ToString::to_string))
+    if let Some(path) = path {
+        path.interpolate_opt(s)
+    } else {
+        s.map(ToString::to_string)
+    }
 }
 
 trait Interpolate {


### PR DESCRIPTION
With 0.13.3, some descriptions were removed from rp2040.svd:
```
--- a/svd/rp2040.svd.patched
+++ b/svd/rp2040.svd.patched
@@ -14513,23 +14513,18 @@
           <fields>
             <field>
               <name>STABLE</name>
-              <description>Oscillator is running and stable</description>
               <bitOffset>31</bitOffset>
               <bitWidth>1</bitWidth>
               <access>read-only</access>
             </field>
             <field>
               <name>DIV_RUNNING</name>
-              <description>post-divider is running
- this resets to 0 but transitions to 1 during chip startup</description>
               <bitOffset>16</bitOffset>
               <bitWidth>1</bitWidth>
               <access>read-only</access>
             </field>
             <field>
               <name>ENABLED</name>
-              <description>Oscillator is enabled but not necessarily running and stable
- this resets to 0 but transitions to 1 during chip startup</description>
               <bitOffset>12</bitOffset>
               <bitWidth>1</bitWidth>
               <access>read-only</access>
```

This patch avoids that.