### PR TITLE
Support defining write constraints for newly created fields

### DIFF
--- a/res/add_register/patch.yaml
+++ b/res/add_register/patch.yaml
@@ -1,0 +1,13 @@
+_svd: ../add/stm32l4x2.svd
+
+DAC1:
+  _add:
+    ANOTHER_REG:
+      addressOffset: 0x04
+      size: 32
+      fields:
+        MPS:
+          bitOffset: 0
+          bitWidth: 5
+          access: read-write
+          writeConstraint: [0, 0x1f]


### PR DESCRIPTION
This updates `make_field()` to honor a writeConstraint field, the same way that `make_register()` does.
I included a new unit test that verifies the behavior.