### PR TITLE
Expand cluster implementation + fix  _strip to work on clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,29 @@ _rebase:
             FIRST_REG: {}
             SECOND_REG: {}
 
+    # clusters can be expanded into individual registers. The name of the resulting register will be the cluster name, concatenated with the register name.
+
+    _expand_cluster:
+        - CLUSTER_ONE*
+        - CLUSTER_TWO*
+
+    # When expanding clusters containing more than one element (as specified by <dim>), each register will have substutute [%] in the cluster name with its index number. If the cluster has a dimIndex element, a %s in the  cluster name will be replaced by dimIndex element. [%] is not compatible with dimIndex, as according to SVD 1.3.10
+    # The SVD 1.3.10 does not specify a delimiter for expansion, so passing the following parameters to the cluster as a hash will allow you to set the delimiter before and after the index is applied (the default delimiters are "_". You can also force the cluster to apply a zero index to a cluster with a single element by passing in the _zeroindex: true parameter
+
+    _expand_cluster:
+        CLUSTER_ONE*:
+        CLUSTER_TWO*:
+          _preindex: "_"
+          _postindex: "_"
+          _zeroindex: true
+
+
+    # if you pass the _noprefix: true parameter to a cluster, the cluster name will not be prefixed with the peripheral name. This is only valid for single element clusters.
+
+    _expand_cluster:
+        CLUSTER_ONE*:
+          _noprefix: true
+
     # A register on this peripheral, matches an SVD <register> tag
     MODER:
         # As in the peripheral scope, rename or redescribe a field.

--- a/res/expand_cluster/expected.svd
+++ b/res/expand_cluster/expected.svd
@@ -1,0 +1,1187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+  <name>MSPM0G350x</name>
+  <version>1.0</version>
+  <description></description>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <peripherals>
+    <peripheral>
+      <name>GPIOB</name>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <groupName>GPIOB</groupName>
+      <baseAddress>0x400A2000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x1F00</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>FSUB_0</name>
+          <description>Subsciber Port 0</description>
+          <addressOffset>0x400</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CHANID</name>
+              <description>0 = disconnected.
+                1-15 = connected to channelID = CHANID.</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UNCONNECTED</name>
+                  <description>A value of 0 specifies that the event is not connected</description>
+                  <value>0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PWREN</name>
+          <description>Power enable</description>
+          <addressOffset>0x800</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the power</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable Power</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable Power</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RSTCTL</name>
+          <description>Reset Control</description>
+          <addressOffset>0x804</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>RESETSTKYCLR</name>
+              <description>Clear the RESETSTKY bit in the STAT register</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NOP</name>
+                  <description>Writing 0 has no effect</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Clear reset sticky bit</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESETASSERT</name>
+              <description>Assert reset to the peripheral</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NOP</name>
+                  <description>Writing 0 has no effect</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASSERT</name>
+                  <description>Assert reset</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STAT</name>
+          <description>Status Register</description>
+          <addressOffset>0x814</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESETSTKY</name>
+              <description>This bit indicates, if the peripheral was reset, since this bit was
+                  cleared
+                  by RESETSTKYCLR in the RSTCTL register</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NORES</name>
+                  <description>The peripheral has not been reset since this bit was last cleared
+                      by
+                      RESETSTKYCLR in the RSTCTL register</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The peripheral was reset since the last bit clear</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TEST_REG_0</name>
+          <description>Reg Description</description>
+          <addressOffset>0x800</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_0[%s]</name>
+          <addressOffset>0x1000</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_1</name>
+          <description>Reg Description</description>
+          <addressOffset>0x818</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_1[%s]</name>
+          <addressOffset>0x1018</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_2</name>
+          <description>Reg Description</description>
+          <addressOffset>0x830</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_2[%s]</name>
+          <addressOffset>0x1030</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_3</name>
+          <description>Reg Description</description>
+          <addressOffset>0x848</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_3[%s]</name>
+          <addressOffset>0x1048</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_A</name>
+          <description>Reg Description</description>
+          <addressOffset>0x800</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_A[%s]</name>
+          <addressOffset>0x1000</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_B</name>
+          <description>Reg Description</description>
+          <addressOffset>0x818</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_B[%s]</name>
+          <addressOffset>0x1018</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_C</name>
+          <description>Reg Description</description>
+          <addressOffset>0x830</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_C[%s]</name>
+          <addressOffset>0x1030</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+        <register>
+          <name>TEST_REG_D</name>
+          <description>Reg Description</description>
+          <addressOffset>0x848</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable the reg</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Disable regster</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>Enable register</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>3</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimIndex>X,Y,Z</dimIndex>
+          <dimArrayIndex/>
+          <name>TEST_NESTED_CLUSTER_D[%s]</name>
+          <addressOffset>0x1048</addressOffset>
+          <register>
+            <name>TEST_NC_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC0</name>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <groupName>DAC</groupName>
+      <baseAddress>0x40018000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x1F00</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DAC0_IIDX_0</name>
+          <description>Interrupt index</description>
+          <addressOffset>0x1020</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>STAT</name>
+              <description>Interrupt index status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NO_INTR</name>
+                  <description>No pending interrupt</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODRDYIFG</name>
+                  <description>Module ready interrupt</description>
+                  <value>2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOFULLIFG</name>
+                  <description>FIFO full interrupt</description>
+                  <value>9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO1B4IFG</name>
+                  <description>FIFO one fourth empty interrupt</description>
+                  <value>10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO1B2IFG</name>
+                  <description>FIFO half empty interrupt</description>
+                  <value>11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO3B4IFG</name>
+                  <description>FIFO three fourth empty interrupt</description>
+                  <value>12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOEMPTYIFG</name>
+                  <description>FIFO empty interrupt</description>
+                  <value>13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOURUNIFG</name>
+                  <description>FIFO underrun interrupt</description>
+                  <value>14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DMADONEIFG</name>
+                  <description>DMA done interrupt</description>
+                  <value>15</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DAC0_IMASK_0</name>
+          <description>Interrupt mask</description>
+          <addressOffset>0x1028</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MODRDYIFG</name>
+              <description>Masks MODRDYIFG</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO1B2IFG</name>
+              <description>Masks FIFO1B2IFG</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOEMPTYIFG</name>
+              <description>Masks FIFOEMPTYIFG</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO1B4IFG</name>
+              <description>Masks FIFO1B4IFG</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO3B4IFG</name>
+              <description>Masks FIFO3B4IFG</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOFULLIFG</name>
+              <description>Masks FIFOFULLIFG</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOURUNIFG</name>
+              <description>Masks FIFOURUNIFG</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DMADONEIFG</name>
+              <description>Masks DMADONEIFG</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DAC0_IIDX_1</name>
+          <description>Interrupt index</description>
+          <addressOffset>0x104C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>STAT</name>
+              <description>Interrupt index status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NO_INTR</name>
+                  <description>No pending interrupt</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODRDYIFG</name>
+                  <description>Module ready interrupt</description>
+                  <value>2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOFULLIFG</name>
+                  <description>FIFO full interrupt</description>
+                  <value>9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO1B4IFG</name>
+                  <description>FIFO one fourth empty interrupt</description>
+                  <value>10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO1B2IFG</name>
+                  <description>FIFO half empty interrupt</description>
+                  <value>11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFO3B4IFG</name>
+                  <description>FIFO three fourth empty interrupt</description>
+                  <value>12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOEMPTYIFG</name>
+                  <description>FIFO empty interrupt</description>
+                  <value>13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FIFOURUNIFG</name>
+                  <description>FIFO underrun interrupt</description>
+                  <value>14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DMADONEIFG</name>
+                  <description>DMA done interrupt</description>
+                  <value>15</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DAC0_IMASK_1</name>
+          <description>Interrupt mask</description>
+          <addressOffset>0x1054</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MODRDYIFG</name>
+              <description>Masks MODRDYIFG</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO1B2IFG</name>
+              <description>Masks FIFO1B2IFG</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOEMPTYIFG</name>
+              <description>Masks FIFOEMPTYIFG</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO1B4IFG</name>
+              <description>Masks FIFO1B4IFG</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFO3B4IFG</name>
+              <description>Masks FIFO3B4IFG</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOFULLIFG</name>
+              <description>Masks FIFOFULLIFG</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FIFOURUNIFG</name>
+              <description>Masks FIFOURUNIFG</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DMADONEIFG</name>
+              <description>Masks DMADONEIFG</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CLR</name>
+                  <description>Interrupt is masked out</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <groupName>CRC</groupName>
+      <baseAddress>0x40440000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <cluster>
+          <dim>1</dim>
+          <dimIncrement>0x18</dimIncrement>
+          <dimArrayIndex/>
+          <name>TEST_CLUSTER_WITH_REG_ARRAY_MEMBER[%s]</name>
+          <addressOffset>0x800</addressOffset>
+          <register>
+            <name>CRC_PWREN</name>
+            <description>Power enable</description>
+            <addressOffset>0x0</addressOffset>
+            <size>0x20</size>
+            <access>read-write</access>
+            <resetValue>0x00000000</resetValue>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the power</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>1</bitWidth>
+                <access>read-write</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable Power</description>
+                    <value>0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable Power</description>
+                    <value>1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <register>
+            <dim>512</dim>
+            <dimIncrement>0x4</dimIncrement>
+            <dimIndex>0-511</dimIndex>
+            <name>TEST_REGISTER_ARRAY_IN_CLUSTER_%s</name>
+            <description>CRC Input Data Array Register</description>
+            <addressOffset>0x1800</addressOffset>
+            <size>0x20</size>
+            <access>write-only</access>
+            <resetValue>0x00000000</resetValue>
+            <resetMask>0xFFFFFFFF</resetMask>
+            <fields>
+              <field>
+                <name>DATA</name>
+                <description>Input Data</description>
+                <bitOffset>0</bitOffset>
+                <bitWidth>32</bitWidth>
+                <access>write-only</access>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/res/expand_cluster/mspm0g350x.svd
+++ b/res/expand_cluster/mspm0g350x.svd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+  xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+  <name>MSPM0G350x</name>
+  <peripherals>
+    <peripheral>
+      <name>GPIOB</name>
+      <groupName>GPIOB</groupName>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <baseAddress>0x400A2000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x1F00</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <cluster>
+          <dim>1</dim>
+          <dimIncrement>24</dimIncrement>
+          <dimArrayIndex>0</dimArrayIndex>
+          <name>GPIOB_GPRCM[%s]</name>
+          <description></description>
+          <addressOffset>0x800</addressOffset>
+          <register>
+            <name>GPIOB_PWREN</name>
+            <description>Power enable</description>
+            <addressOffset>0x0</addressOffset>
+            <size>32</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the power</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable Power</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable Power</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <register>
+            <name>GPIOB_RSTCTL</name>
+            <description>Reset Control</description>
+            <addressOffset>0x4</addressOffset>
+            <size>32</size>
+            <access>write-only</access>
+            <fields>
+              <field>
+                <name>RESETSTKYCLR</name>
+                <description>Clear the RESETSTKY bit in the STAT register</description>
+                <bitOffset>0x1</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <access>write-only</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>NOP</name>
+                    <description>Writing 0 has no effect</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Clear reset sticky bit</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>RESETASSERT</name>
+                <description>Assert reset to the peripheral</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <access>write-only</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>NOP</name>
+                    <description>Writing 0 has no effect</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ASSERT</name>
+                    <description>Assert reset</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <register>
+            <name>GPIOB_STAT</name>
+            <description>Status Register</description>
+            <addressOffset>0x14</addressOffset>
+            <size>32</size>
+            <access>read-only</access>
+            <fields>
+              <field>
+                <name>RESETSTKY</name>
+                <description>This bit indicates, if the peripheral was reset, since this bit was
+                  cleared
+                  by RESETSTKYCLR in the RSTCTL register</description>
+                <bitOffset>0x10</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <access>read-only</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>NORES</name>
+                    <description>The peripheral has not been reset since this bit was last cleared
+                      by
+                      RESETSTKYCLR in the RSTCTL register</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>RESET</name>
+                    <description>The peripheral was reset since the last bit clear</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/res/expand_cluster/mspm0g350x.svd
+++ b/res/expand_cluster/mspm0g350x.svd
@@ -16,6 +16,173 @@
         <usage>registers</usage>
       </addressBlock>
       <registers>
+        <register>
+          <name>GPIOB_FSUB_0</name>
+          <description>Subsciber Port 0</description>
+          <addressOffset>0x400</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CHANID</name>
+              <description>0 = disconnected.
+                1-15 = connected to channelID = CHANID.</description>
+              <bitOffset>0x0</bitOffset>
+              <bitWidth>0x4</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UNCONNECTED</name>
+                  <description>A value of 0 specifies that the event is not connected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <cluster>
+          <dim>4</dim>
+          <dimIncrement>24</dimIncrement>
+          <dimArrayIndex />
+          <name>TEST_CLUSTER_NO_INDEX[%s]</name>
+          <description></description>
+          <addressOffset>0x800</addressOffset>
+          <register>
+            <name>TEST_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>32</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <cluster>
+            <dim>3</dim>
+            <dimIncrement>24</dimIncrement>
+            <dimIndex>X,Y,Z</dimIndex>
+            <dimArrayIndex></dimArrayIndex>
+            <name>TEST_NESTED_CLUSTER%s</name>
+            <description></description>
+            <addressOffset>0x800</addressOffset>
+            <register>
+              <name>TEST_NC_REG</name>
+              <description>Reg Description</description>
+              <addressOffset>0x0</addressOffset>
+              <size>32</size>
+              <access>read-write</access>
+              <fields>
+                <field>
+                  <name>ENABLE</name>
+                  <description>Enable the reg</description>
+                  <bitOffset>0x0</bitOffset>
+                  <bitWidth>0x1</bitWidth>
+                  <enumeratedValues>
+                    <enumeratedValue>
+                      <name>DISABLE</name>
+                      <description>Disable regster</description>
+                      <value>0x0</value>
+                    </enumeratedValue>
+                    <enumeratedValue>
+                      <name>ENABLE</name>
+                      <description>Enable register</description>
+                      <value>0x1</value>
+                    </enumeratedValue>
+                  </enumeratedValues>
+                </field>
+              </fields>
+            </register>
+          </cluster>
+        </cluster>
+        <cluster>
+          <dim>4</dim>
+          <dimIncrement>24</dimIncrement>
+          <dimIndex>A,B,C,D</dimIndex>
+          <dimArrayIndex></dimArrayIndex>
+          <name>TEST_CLUSTER_WITH_INDEX%s</name>
+          <description></description>
+          <addressOffset>0x800</addressOffset>
+          <register>
+            <name>TEST_REG</name>
+            <description>Reg Description</description>
+            <addressOffset>0x0</addressOffset>
+            <size>32</size>
+            <access>read-write</access>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the reg</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable regster</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable register</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <cluster>
+            <dim>3</dim>
+            <dimIncrement>24</dimIncrement>
+            <dimIndex>X,Y,Z</dimIndex>
+            <dimArrayIndex></dimArrayIndex>
+            <name>TEST_NESTED_CLUSTER[%s]</name>
+            <description></description>
+            <addressOffset>0x800</addressOffset>
+            <register>
+              <name>TEST_NC_REG</name>
+              <description>Reg Description</description>
+              <addressOffset>0x0</addressOffset>
+              <size>32</size>
+              <access>read-write</access>
+              <fields>
+                <field>
+                  <name>ENABLE</name>
+                  <description>Enable the reg</description>
+                  <bitOffset>0x0</bitOffset>
+                  <bitWidth>0x1</bitWidth>
+                  <enumeratedValues>
+                    <enumeratedValue>
+                      <name>DISABLE</name>
+                      <description>Disable regster</description>
+                      <value>0x0</value>
+                    </enumeratedValue>
+                    <enumeratedValue>
+                      <name>ENABLE</name>
+                      <description>Enable register</description>
+                      <value>0x1</value>
+                    </enumeratedValue>
+                  </enumeratedValues>
+                </field>
+              </fields>
+            </register>
+          </cluster>
+        </cluster>
         <cluster>
           <dim>1</dim>
           <dimIncrement>24</dimIncrement>
@@ -126,6 +293,327 @@
                     <value>0x1</value>
                   </enumeratedValue>
                 </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC0</name>
+      <groupName>DAC</groupName>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <baseAddress>0x40018000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x1F00</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <cluster>
+          <dim>2</dim>
+          <dimIncrement>44</dimIncrement>
+          <dimArrayIndex>0,1</dimArrayIndex>
+          <name>DAC0_INT_EVENT[%s]</name>
+          <description></description>
+          <addressOffset>0x1020</addressOffset>
+          <register>
+            <name>DAC0_IIDX</name>
+            <description>Interrupt index</description>
+            <addressOffset>0x0</addressOffset>
+            <size>32</size>
+            <access>read-only</access>
+            <resetValue>0x00000000</resetValue>
+            <fields>
+              <field>
+                <name>STAT</name>
+                <description>Interrupt index status</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x4</bitWidth>
+                <access>read-only</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>NO_INTR</name>
+                    <description>No pending interrupt</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>MODRDYIFG</name>
+                    <description>Module ready interrupt</description>
+                    <value>0x2</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFOFULLIFG</name>
+                    <description>FIFO full interrupt</description>
+                    <value>0x9</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFO1B4IFG</name>
+                    <description>FIFO one fourth empty interrupt</description>
+                    <value>0xA</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFO1B2IFG</name>
+                    <description>FIFO half empty interrupt</description>
+                    <value>0xB</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFO3B4IFG</name>
+                    <description>FIFO three fourth empty interrupt</description>
+                    <value>0xC</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFOEMPTYIFG</name>
+                    <description>FIFO empty interrupt</description>
+                    <value>0xD</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>FIFOURUNIFG</name>
+                    <description>FIFO underrun interrupt</description>
+                    <value>0xE</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>DMADONEIFG</name>
+                    <description>DMA done interrupt</description>
+                    <value>0xF</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <register>
+            <name>DAC0_IMASK</name>
+            <description>Interrupt mask</description>
+            <addressOffset>0x8</addressOffset>
+            <size>32</size>
+            <access>read-write</access>
+            <resetValue>0x00000000</resetValue>
+            <fields>
+              <field>
+                <name>MODRDYIFG</name>
+                <description>Masks MODRDYIFG</description>
+                <bitOffset>0x1</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFO1B2IFG</name>
+                <description>Masks FIFO1B2IFG</description>
+                <bitOffset>0xA</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFOEMPTYIFG</name>
+                <description>Masks FIFOEMPTYIFG</description>
+                <bitOffset>0xC</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFO1B4IFG</name>
+                <description>Masks FIFO1B4IFG</description>
+                <bitOffset>0x9</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFO3B4IFG</name>
+                <description>Masks FIFO3B4IFG</description>
+                <bitOffset>0xB</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFOFULLIFG</name>
+                <description>Masks FIFOFULLIFG</description>
+                <bitOffset>0x8</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>FIFOURUNIFG</name>
+                <description>Masks FIFOURUNIFG</description>
+                <bitOffset>0xD</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+              <field>
+                <name>DMADONEIFG</name>
+                <description>Masks DMADONEIFG</description>
+                <bitOffset>0xE</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>CLR</name>
+                    <description>Interrupt is masked out</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>SET</name>
+                    <description>Interrupt will request an interrupt service routine and
+                      corresponding bit in MIS will be set</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+        </cluster>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <groupName>CRC</groupName>
+      <version>1.0</version>
+      <description>PERIPHERALREGION</description>
+      <baseAddress>0x40440000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <cluster>
+          <dim>1</dim>
+          <dimIncrement>24</dimIncrement>
+          <dimArrayIndex>0</dimArrayIndex>
+          <name>TEST_CLUSTER_WITH_REG_ARRAY_MEMBER[%s]</name>
+          <description></description>
+          <addressOffset>0x800</addressOffset>
+          <register>
+            <name>CRC_PWREN</name>
+            <description>Power enable</description>
+            <addressOffset>0x0</addressOffset>
+            <size>32</size>
+            <access>read-write</access>
+            <resetValue>0x00000000</resetValue>
+            <fields>
+              <field>
+                <name>ENABLE</name>
+                <description>Enable the power</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x1</bitWidth>
+                <access>read-write</access>
+                <enumeratedValues>
+                  <enumeratedValue>
+                    <name>DISABLE</name>
+                    <description>Disable Power</description>
+                    <value>0x0</value>
+                  </enumeratedValue>
+                  <enumeratedValue>
+                    <name>ENABLE</name>
+                    <description>Enable Power</description>
+                    <value>0x1</value>
+                  </enumeratedValue>
+                </enumeratedValues>
+              </field>
+            </fields>
+          </register>
+          <register>
+            <dim>512</dim>
+            <dimIncrement>4</dimIncrement>
+            <dimIndex>
+              0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,340,341,342,343,344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,360,361,362,363,364,365,366,367,368,369,370,371,372,373,374,375,376,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,394,395,396,397,398,399,400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,419,420,421,422,423,424,425,426,427,428,429,430,431,432,433,434,435,436,437,438,439,440,441,442,443,444,445,446,447,448,449,450,451,452,453,454,455,456,457,458,459,460,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,478,479,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,504,505,506,507,508,509,510,511</dimIndex>
+            <name>TEST_REGISTER_ARRAY_IN_CLUSTER_%s</name>
+            <description>CRC Input Data Array Register</description>
+            <addressOffset>0x1800</addressOffset>
+            <size>32</size>
+            <access>write-only</access>
+            <resetValue>0x00000000</resetValue>
+            <resetMask>0xffffffff</resetMask>
+            <fields>
+              <field>
+                <name>DATA</name>
+                <description>Input Data</description>
+                <bitOffset>0x0</bitOffset>
+                <bitWidth>0x20</bitWidth>
+                <access>write-only</access>
               </field>
             </fields>
           </register>

--- a/res/expand_cluster/patch.yml
+++ b/res/expand_cluster/patch.yml
@@ -1,0 +1,7 @@
+_svd: "./mspm0g350x.svd"
+
+# Alter top-level information and peripherals for this device
+"GPIO*":
+  _expand_cluster:
+    - "GPIO?_GPRCM*"
+  _strip: "GPIO?_"

--- a/res/expand_cluster/patch.yml
+++ b/res/expand_cluster/patch.yml
@@ -2,6 +2,23 @@ _svd: "./mspm0g350x.svd"
 
 # Alter top-level information and peripherals for this device
 "GPIO*":
-  _expand_cluster:
-    - "GPIO?_GPRCM*"
   _strip: "GPIO?_"
+  _clusters:
+    "*":
+      _strip: "GPIO?_"
+  _expand_cluster:
+    GPRCM*:
+      _preindex: "_"
+      _postindex: "_"
+      _zeroindex: false
+      _noprefix: true
+    TEST_CLUSTER*:
+
+"DAC*":
+  _strip: "DAC?_"
+  _clusters:
+    "INT_EVENT*":
+      _strip: "DAC?_"
+  _expand_cluster:
+    - "?~missing_cluster"
+    - "INT_EVENT*"


### PR DESCRIPTION
Implemented _expand_cluster, and added an example.

It takes a string or an array of strings as arguments.

Added an example in /res/expand_cluster and updated the readme

closes: https://github.com/rust-embedded/svdtools/issues/246
