### PR TITLE
svdtools/patch: Fix bug when _include is a single item.

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -133,7 +133,10 @@ def yaml_includes(parent):
         if not pspec.startswith("_") and "_include" in parent[pspec]:
             parent[pspec]["_path"] = parent["_path"]
             included += yaml_includes(parent[pspec])
-    for relpath in parent.get("_include", []):
+    include = parent.get("_include", [])
+    if isinstance(include, str):
+        include = [include]
+    for relpath in include:
         path = abspath(parent["_path"], relpath)
         if path in included:
             continue


### PR DESCRIPTION
An example of a file that triggers this bug can be found in https://github.com/esp-rs/esp-pacs/blob/main/esp32/svd/patches/esp32.yaml