### PR TITLE
Make CLI optional (for library usage)

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -13,7 +13,17 @@ jobs:
   rust-ci:
     name: Rust-CI
     runs-on: ubuntu-latest
-    needs: [build, test, test_convert, clippy, format, check]
+    needs:
+      - build
+      - test
+      - test_convert
+      - clippy
+      - format
+      - check
+      - library
+      - library_test
+      - configless
+      - configless_test
     if: always()
     steps:
       - name: Done
@@ -80,3 +90,40 @@ jobs:
           cargo install svdtools --path .
       - name: Check
         run: bash tools/check_${{ matrix.target }}.sh
+
+  library:
+    name: Library Build
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo build --no-default-features
+      - run: cargo doc --no-default-features
+  library_test:
+    name: Library Test
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test --no-default-features
+  configless:
+    name: Configless Build
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo build --no-default-features --features bin
+      - run: cargo doc --no-default-features --features bin
+  configless_test:
+    name: Configless Test
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test --no-default-features --features bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,26 +26,26 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive", "cargo", "color"] }
+clap = { version = "4.5", features = ["derive", "cargo", "color"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 svd-rs = { version = "0.14.12", features = ["serde", "derive-from"] }
 svd-parser = { version = "0.14.9", features = ["expand"] }
 svd-encoder = "0.14.7"
 # serde_yaml 0.9.x looks broken
-serde_yaml = "0.8.26"
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_yaml = { version = "0.8.26", optional = true }
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 anyhow = "1.0.97"
 thiserror = "1.0.35"
 hashlink = "0.10.0"
 globset = "0.4.16"
 commands = "0.0.5"
-env_logger = "0.11"
+env_logger = { version = "0.11", optional = true }
 log = { version = "~0.4", features = ["std"] }
 normpath = "1.3.0"
-liquid = "0.26.11"
+liquid = { version = "0.26.11", optional = true }
 once_cell = "1.21.0"
-rayon = "1.7.0"
+rayon = { version = "1.7.0", optional = true }
 regex = "1.10"
 itertools = "0.14.0"
 phf = { version = "0.11", features = ["macros"] }
@@ -57,3 +57,22 @@ version = "0.10"
 [dev-dependencies]
 similar = "2.5.0"
 tempfile = "3.18"
+
+[[bin]]
+doc = false
+name = "svdtools"
+path = "src/main.rs"
+required-features = ["bin"]
+
+[features]
+default = ["bin", "json", "yaml"]
+
+bin = [
+    "dep:liquid",
+    "dep:rayon",
+    "dep:clap",
+    "dep:env_logger",
+]
+
+json = ["dep:serde_json"]
+yaml = ["dep:serde_yaml"]

--- a/src/convert/convert_cli.rs
+++ b/src/convert/convert_cli.rs
@@ -11,7 +11,9 @@ pub use crate::ConfigFormat;
 #[non_exhaustive]
 pub enum InputFormat {
     Xml,
+    #[cfg(feature = "yaml")]
     Yaml,
+    #[cfg(feature = "json")]
     Json,
 }
 
@@ -20,7 +22,9 @@ impl FromStr for InputFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "svd" | "SVD" | "xml" | "XML" => Ok(Self::Xml),
+            #[cfg(feature = "yaml")]
             "yml" | "yaml" | "YAML" => Ok(Self::Yaml),
+            #[cfg(feature = "json")]
             "json" | "JSON" => Ok(Self::Json),
             _ => Err(anyhow!("Unknown input file format")),
         }
@@ -31,7 +35,9 @@ impl FromStr for InputFormat {
 #[non_exhaustive]
 pub enum OutputFormat {
     Xml,
+    #[cfg(feature = "yaml")]
     Yaml,
+    #[cfg(feature = "json")]
     Json,
 }
 
@@ -40,7 +46,9 @@ impl FromStr for OutputFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "svd" | "SVD" | "xml" | "XML" => Ok(Self::Xml),
+            #[cfg(feature = "yaml")]
             "yml" | "yaml" | "YAML" => Ok(Self::Yaml),
+            #[cfg(feature = "json")]
             "json" | "JSON" => Ok(Self::Json),
             _ => Err(anyhow!("Unknown output file format")),
         }
@@ -75,7 +83,9 @@ pub fn open_svd(
             &input,
             &svd_parser::Config::default().ignore_enums(parser_config.ignore_enums),
         )?,
+        #[cfg(feature = "yaml")]
         InputFormat::Yaml => serde_yaml::from_str(&input)?,
+        #[cfg(feature = "json")]
         InputFormat::Json => serde_json::from_str(&input)?,
     };
     if parser_config.expand_properties {
@@ -111,7 +121,9 @@ pub fn convert(
 
     let output = match output_format {
         OutputFormat::Xml => svd_encoder::encode_with_config(&device, &config)?,
+        #[cfg(feature = "yaml")]
         OutputFormat::Yaml => serde_yaml::to_string(&device)?,
+        #[cfg(feature = "json")]
         OutputFormat::Json => serde_json::to_string_pretty(&device)?,
     };
 

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "bin")]
 pub mod convert_cli;

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "bin")]
 pub mod html_cli;
+#[cfg(feature = "bin")]
 pub mod htmlcompare_cli;

--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "bin")]
 mod interrupt_list;
+#[cfg(feature = "bin")]
 pub mod interrupts_cli;
+#[cfg(feature = "bin")]
 mod svd_reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
-use std::io::Read;
-use std::{fs::File, path::Path, str::FromStr};
+use std::path::Path;
+#[cfg(any(feature = "json", feature = "yaml"))]
+use std::{fs::File, io::Read, str::FromStr};
 
 pub mod common;
 pub mod convert;
@@ -14,21 +15,27 @@ pub mod patch;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ConfigFormat {
+    #[cfg(feature = "yaml")]
     Yaml,
+    #[cfg(feature = "json")]
     Json,
 }
 
+#[cfg(any(feature = "json", feature = "yaml"))]
 impl FromStr for ConfigFormat {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            #[cfg(feature = "yaml")]
             "yml" | "yaml" | "YAML" => Ok(Self::Yaml),
+            #[cfg(feature = "json")]
             "json" | "JSON" => Ok(Self::Json),
             _ => Err(anyhow!("Unknown config file format")),
         }
     }
 }
 
+#[cfg(any(feature = "json", feature = "yaml"))]
 pub(crate) fn get_encoder_config(
     format_config: Option<&Path>,
 ) -> anyhow::Result<svd_encoder::Config> {
@@ -41,7 +48,9 @@ pub(crate) fn get_encoder_config(
         File::open(format_config)?.read_to_string(&mut config)?;
 
         let config_map: std::collections::HashMap<String, String> = match config_format {
+            #[cfg(feature = "yaml")]
             ConfigFormat::Yaml => serde_yaml::from_str(&config)?,
+            #[cfg(feature = "json")]
             ConfigFormat::Json => serde_json::from_str(&config)?,
         };
 
@@ -54,6 +63,19 @@ pub(crate) fn get_encoder_config(
     } else {
         svd_encoder::Config::default()
     })
+}
+
+#[cfg(not(any(feature = "json", feature = "yaml")))]
+
+pub(crate) fn get_encoder_config(
+    format_config: Option<&Path>,
+) -> anyhow::Result<svd_encoder::Config> {
+    if let Some(format_config) = format_config {
+        Err(anyhow!("In path: {}", format_config.display())
+            .context("Config file passed to a build of svdtools that does not support it"))
+    } else {
+        Ok(svd_encoder::Config::default())
+    }
 }
 
 #[cfg(test)]

--- a/src/makedeps/mod.rs
+++ b/src/makedeps/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "bin")]
 pub mod makedeps_cli;

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "bin")]
 pub mod mmap_cli;

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "bin")]
 pub mod patch_cli;
 
 use once_cell::sync::Lazy;
@@ -48,8 +49,8 @@ pub struct Config {
 }
 
 /// Derive level when several identical enumerationValues added in a field
-#[derive(clap::ValueEnum)]
-#[value(rename_all = "lower")]
+#[cfg_attr(feature = "bin", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "bin", value(rename_all = "lower"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum EnumAutoDerive {
     #[default]

--- a/tests/example1.rs
+++ b/tests/example1.rs
@@ -7,7 +7,7 @@ fn example1() {
     let expected_svd_path = test_dir.join("expected.svd");
     let expected_svd = svd_reader::device(&expected_svd_path).unwrap();
 
-    patch::patch_cli::patch(
+    patch::process_file(
         &test_dir.join("patch.yaml"),
         None,
         None,


### PR DESCRIPTION
This is made by adding a "bin" feature that's enabled by default, inspired by what was done in https://github.com/rust-embedded/svd2rust/pull/619.

Additionally, support for JSON and YAML configs has also been made optional but default. This includes what should be the only behavior change: if neither were enabled at build-time, passing a config file is an error.

The motivation came from https://github.com/Rahix/avr-device/issues/201, but this should be a generally beneficial change for everybody.

Since some of the features of the CLI aren't very useful when using svdtools as a library, they just vanish without the "bin" feature. This is for two reasons: one is to reduce diff size, and two is to avoid having to refactor all capabilities to have a library equivalent. There is little disadvantage to this, for instance in avr-device we only use the patching functionality (which is kept), and there's little prospect of needing more.